### PR TITLE
Adding sort folders after files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add a sorting feature for the Atom tree-view package.
 *   File change time
 *   File modify time
 *   File creation time
-*   File group name, group mean "component", "directive" etc, e.g. "a.component.js" "b.component.js" "a.directive.js" "b.directive.js"
+*   File group name ("file group" means "component", "directive" etc, e.g. "a.component.js" "b.component.js" "a.directive.js" "b.directive.js")
 
 ### Descending Sorting
 
@@ -26,6 +26,6 @@ You can set descending sorting or ascending sorting.
 
 You can set case-sensitive sorting or case-insensitive sorting.
 
-### Sort Folders Before Files
+### Sort Folders Before or After Files
 
-When listing directory items, list subdirectories before listing files.
+When listing directory items, list subdirectories before or after files.

--- a/lib/tree-view-sort.js
+++ b/lib/tree-view-sort.js
@@ -5,11 +5,11 @@ import path from 'path';
 import fs from 'fs-plus';
 
 let oldSortEntries,
-  sortType,
-  oldSortType,
   isDescending,
   isCaseSensitive,
-  isSortFoldersBeforeFiles;
+  sortType,
+  oldSortType,
+  sortFolders;
 
 const getFileExtension = (filename) => {
   return filename.slice((filename.lastIndexOf('.') - 1 >>> 0) + 2);
@@ -159,7 +159,7 @@ const sortEntries = function(combinedEntries) {
     const firstName = normalizeEntryName(first);
     const secondName = normalizeEntryName(second);
 
-    if (isDir(first) && isSortFoldersBeforeFiles) {
+    if (isDir(first) && sortFolders != 0) {
       if (isDir(second)) {
         if (firstName.indexOf('.') === 0 && secondName.indexOf('.') !== 0) {
           return -1;
@@ -172,12 +172,12 @@ const sortEntries = function(combinedEntries) {
         }
       }
       else {
-        return -1;
+        return (sortFolders == 1) ? -1 : 1;
       }
     }
     else {
-      if (isDir(second) && isSortFoldersBeforeFiles) {
-        return 1;
+      if (isDir(second) && sortFolders != 0) {
+        return (sortFolders == 1) ? 1 : -1;
       }
       else {
         if (firstName.indexOf('.') === 0 && secondName.indexOf('.') !== 0) {
@@ -257,10 +257,19 @@ export default {
       return;
     }
 
-    sortType = atom.config.get('tree-view-sort.type');
     isDescending = atom.config.get('tree-view-sort.descending');
     isCaseSensitive = atom.config.get('tree-view-sort.caseSensitive');
-    isSortFoldersBeforeFiles = atom.config.get('tree-view-sort.sortFoldersBeforeFiles');
+    sortType = atom.config.get('tree-view-sort.type');
+    sortFolders = atom.config.get('tree-view-sort.sortFolders');
+
+    sortFoldersBeforeFiles = atom.config.get('tree-view-sort.sortFoldersBeforeFiles');
+    if (typeof sortFoldersBeforeFiles != 'undefined') {
+      let settings = atom.config.get('tree-view-sort');
+      delete(settings.sortFoldersBeforeFiles);
+      settings.sortFolders = (sortFoldersBeforeFiles) ? 1 : 0;
+      atom.config.set('tree-view-sort', settings);
+      sortFolders = settings.sortFolders;
+    }
 
     oldSortEntries = this.treeView.roots[0].directory.constructor.prototype.sortEntries;
 
@@ -298,8 +307,8 @@ export default {
       }
     }));
 
-    this.subscriptions.add(atom.config.onDidChange('tree-view-sort.sortFoldersBeforeFiles', ({newValue}) => {
-      isSortFoldersBeforeFiles = newValue;
+    this.subscriptions.add(atom.config.onDidChange('tree-view-sort.sortFolders', ({newValue}) => {
+      sortFolders = newValue;
 
       if (sortType) {
         this.reload();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,20 @@
     "fs-plus": "^3.0.0"
   },
   "configSchema": {
+    "descending": {
+      "title": "Descending Sorting",
+      "description": "Use descending sorting, otherwise use ascending sorting. Unavailable when the tree-view-sort package is disabled.",
+      "type": "boolean",
+      "default": false,
+      "order": 1
+    },
+    "caseSensitive": {
+      "title": "Case-Sensitive Sorting",
+      "description": "Use case-sensitive sorting, otherwise use case-insensitive sorting. Unavailable when the tree-view-sort package is disabled.",
+      "type": "boolean",
+      "default": true,
+      "order": 2
+    },
     "type": {
       "title": "Sort By",
       "description": "The sorting type of the Atom tree-view package.",
@@ -61,27 +75,27 @@
           "description": "File group name"
         }
       ],
-      "order": 1
-    },
-    "descending": {
-      "title": "Descending Sorting",
-      "description": "Use descending sorting, otherwise use ascending sorting. Unavailable when the tree-view-sort package is disabled.",
-      "type": "boolean",
-      "default": false,
-      "order": 2
-    },
-    "caseSensitive": {
-      "title": "Case-Sensitive Sorting",
-      "description": "Use case-sensitive sorting, otherwise use case-insensitive sorting. Unavailable when the tree-view-sort package is disabled.",
-      "type": "boolean",
-      "default": true,
       "order": 3
     },
-    "sortFoldersBeforeFiles": {
-      "title": "Sort Folders Before Files",
-      "description": "When listing directory items, list subdirectories before listing files.",
-      "type": "boolean",
-      "default": true,
+    "sortFolders": {
+      "title": "Sort Folders",
+      "description": "When listing directory items, sort folders before or after files.",
+      "type": "integer",
+      "default": 1,
+      "enum" : [
+          {
+            "value": 0,
+            "description": "Sort files and folders together (normal behaviour)"
+          },
+          {
+            "value": 1,
+            "description": "Sort folders before files"
+          },
+          {
+            "value": 2,
+            "description": "Sort folders after files"
+          }
+      ],
       "order": 4
     }
   }


### PR DESCRIPTION
I've added the option to sort folders after files. This meant I had to change the `sortFolders` option to a drop-down. I rearranged the order of the settings form to make it more visually appealing. I've also changed the name of the `sortFoldersBeforeFiles` parameter and written code to remove it from the config file, while updating it to the new `sortFolders`.

Hope these changes are acceptable :)