### PR TITLE
Added an option that not to sort folders

### DIFF
--- a/lib/tree-view-sort.js
+++ b/lib/tree-view-sort.js
@@ -179,7 +179,9 @@ const sortEntries = function(combinedEntries) {
     const firstName = normalizeEntryName(first);
     const secondName = normalizeEntryName(second);
 
-    if (isDir(first) && sortFolders != 0) {
+    if ((sortFolders === 3) && (isDir(first)||isDir(second))) {
+      return (isDir(first)) ? -1 : 1;
+    } else if (isDir(first) && sortFolders != 0) {
       if (isDir(second)) {
         if (firstName.indexOf('.') === 0 && secondName.indexOf('.') !== 0) {
           return -1;

--- a/package.json
+++ b/package.json
@@ -98,6 +98,10 @@
         {
           "value": 2,
           "description": "Sort folders after files"
+        },
+        {
+          "value": 3,
+          "description": "Don't sort folders"
         }
       ],
       "order": 4


### PR DESCRIPTION
我想把atom当成一个笔记管理工具，此时我希望tree view里面的文件夹是按照默认的方式排序，不因创建/修改该文件夹下的文件而改变了文件夹的顺序，类似现有的evernote或者Wiz之类的工具。
此次提交的修改正是为了该目的。