### PR TITLE
Fix Windows example

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     },
     "dirsToApplyToRegEx": {
       "title": "Directories to apply to",
-      "description": "RegEx defining what directories to apply settings to. Regex matches against full path. Leave blank to apply to all dirs. (ex: 'tmp', '^/home/chris/tmp$', 'dir1|dir2', '^C:\\Users\\chris\\mydir$')",
+      "description": "RegEx defining what directories to apply settings to. Regex matches against full path. Leave blank to apply to all dirs. (ex: 'tmp', '^/home/chris/tmp$', 'dir1|dir2', '^C:&bsol;&bsol;Users&bsol;&bsol;chris&bsol;&bsol;mydir$')",
       "type": "string",
       "default": "",
       "order": 6


### PR DESCRIPTION
Fix the windows directory example.

Here is how it displays in Atom:
![image](https://user-images.githubusercontent.com/5075659/86070119-d8bf0e00-ba49-11ea-8396-e518f5fb9377.png)
